### PR TITLE
Add a parameter buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ $(document).ready(function(){
 * `dragDirection` : `horizontal` || `vertical`, `horizontal` is default.
 * `useKeys` : `true` || `false`, `false` is default
 * `draggable` : `true` || `false`, `true` is default
+* `buffer` : `move space ignore`, `0` is default
 
 #### api
 

--- a/assets/js/jquery.threesixty.js
+++ b/assets/js/jquery.threesixty.js
@@ -14,7 +14,8 @@ var scope,
     defaults = {
         dragDirection: 'horizontal',
         useKeys: false,
-        draggable: true
+        draggable: true,
+        buffer: 0
     },
     dragDirections = ['horizontal', 'vertical'],
     options = {},
@@ -251,19 +252,21 @@ var scope,
 
             $downElem.trigger('move');
 
-            if(options.dragDirection === 'vertical'){
-                if(y > lastY){
+            if (options.dragDirection === 'vertical') {
+                if(y > lastY && y - lastY > options.buffer){
                     val = lastVal + 1;
-                }else{
+                }else if(y < lastY && lastY - y > options.buffer){
                     val = lastVal - 1;
-                }
-            }else{
-                if(x > lastX){
-                    val = lastVal + 1;
-                }else if(x === lastX){
+                }else {
                     return;
-                }else{
+                }
+            } else {
+                if(x > lastX && x - lastX > options.buffer){
+                    val = lastVal + 1;
+                }else if(x < lastX && lastX - x > options.buffer){
                     val = lastVal - 1;
+                }else {
+                    return;
                 }
             }
 


### PR DESCRIPTION
When moving mouse, the speed of the pictures switch was too fast. So adding a parameter named buffer which can be set by the user to ignore some space of mouse move in order to slow down the switching speed.